### PR TITLE
fix exception when chrome-cli executes js to extract json object or numb...

### DIFF
--- a/chrome-cli/App.m
+++ b/chrome-cli/App.m
@@ -248,7 +248,7 @@ static NSString * const kJsPrintSource = @"(function() { return document.getElem
     if (tab) {
         id data = [tab executeJavascript:js];
         if (data) {
-            printf("%s\n", [(NSString *)data UTF8String]);
+            printf("%s\n", [[NSString stringWithFormat:@"%@", data] UTF8String]);
         }
     }
 }
@@ -261,7 +261,7 @@ static NSString * const kJsPrintSource = @"(function() { return document.getElem
     if (tab) {
         id data = [tab executeJavascript:js];
         if (data) {
-            printf("%s\n", [(NSString *)data UTF8String]);
+            printf("%s\n", [[NSString stringWithFormat:@"%@", data] UTF8String]);
         }
     }
 }


### PR DESCRIPTION
this commit fixes exeptions when chrome-cli executes js to extract json object or number.

```
$ chrome-cli execute '1'
2014-02-14 21:34:27.129 chrome-cli[35875:707] -[__NSCFNumber UTF8String]: unrecognized selector sent to instance 0x187
2014-02-14 21:34:27.130 chrome-cli[35875:707] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber UTF8String]: unrecognized selector sent to instance 0x187'
...
```
