### PR TITLE
Add support for MS Edge on Mac

### DIFF
--- a/scripts/edge-cli
+++ b/scripts/edge-cli
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export CHROME_BUNDLE_IDENTIFIER="com.microsoft.edgemac"
+chrome-cli "$@"


### PR DESCRIPTION
This PR adds an additional shell script wrapper for the Microsoft Edge Browser for Mac. 
Tested as working with latest chrome-cli and Edge, both installed via homebrew on macOS Monterey. 

(I use chrome-cli daily; thank you for the JSON support, super useful)
