### PR TITLE
add command to list tabs' with the link

### DIFF
--- a/chrome-cli/App.h
+++ b/chrome-cli/App.h
@@ -24,6 +24,7 @@ typedef enum {
 - (void)listTabsLinks:(Arguments *)args;
 - (void)listTabsInWindow:(Arguments *)args;
 - (void)listTabsLinksInWindow:(Arguments *)args;
+- (void)listTabsWithLink:(Arguments *)args;
 - (void)printActiveTabInfo:(Arguments *)args;
 - (void)printTabInfo:(Arguments *)args;
 - (void)openUrlInNewTab:(Arguments *)args;

--- a/chrome-cli/App.m
+++ b/chrome-cli/App.m
@@ -117,7 +117,7 @@ static NSString * const kJsPrintSource = @"(function() { return document.getElem
     }
 }
 
-- (void)listTabsLinks:(Arguments *)args {
+- (void)listTabLinks:(Arguments *)args {
     if (self->outputFormat == kOutputFormatJSON) {
         NSMutableArray *tabInfos = [[NSMutableArray alloc] init];
 
@@ -151,6 +151,37 @@ static NSString * const kJsPrintSource = @"(function() { return document.getElem
     }
 }
 
+- (void)listTabsWithLink:(Arguments *)args {
+    if (self->outputFormat == kOutputFormatJSON) {
+        NSMutableArray *tabInfos = [[NSMutableArray alloc] init];
+        for(chromeWindow *window in self.chrome.windows) {
+            for (chromeTab *tab in window.tabs) {
+                NSDictionary *tabInfo = @{
+                    @"windowId": @(window.id),
+                    @"windowName": window.name,
+                    @"id": @(tab.id),
+                    @"title": tab.title,
+                    @"url": tab.URL,
+                };
+                [tabInfos addObject:tabInfo];
+            }
+        }
+        NSDictionary *output = @{
+            @"tabs": tabInfos,
+        };
+        [self printJson:output];
+    } else {
+        for (chromeWindow *window in self.chrome.windows) {
+            for (chromeTab *tab in window.tabs) {
+                if (self.chrome.windows.count > 1) {
+                    printf("[%ld:%ld] %s:%s\n", (long)window.id, (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
+                } else {
+                    printf("[%ld] %s:%s\n", (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
+                }
+            }
+        }
+    }
+}
 
 - (void)listTabsInWindow:(Arguments *)args {
     NSInteger windowId = [args asInteger:@"id"];

--- a/chrome-cli/App.m
+++ b/chrome-cli/App.m
@@ -174,9 +174,9 @@ static NSString * const kJsPrintSource = @"(function() { return document.getElem
         for (chromeWindow *window in self.chrome.windows) {
             for (chromeTab *tab in window.tabs) {
                 if (self.chrome.windows.count > 1) {
-                    printf("[%ld:%ld] %s:%s\n", (long)window.id, (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
+                    printf("[%ld:%ld] title: %s, url: %s\n", (long)window.id, (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
                 } else {
-                    printf("[%ld] %s:%s\n", (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
+                    printf("[%ld] title: %s, url: %s\n", (long)tab.id, tab.title.UTF8String, tab.URL.UTF8String);
                 }
             }
         }

--- a/chrome-cli/main.m
+++ b/chrome-cli/main.m
@@ -41,6 +41,7 @@ int main(int argc, const char * argv[])
     [argonaut add:@"list tabs -w <id>" target:app action:@selector(listTabsInWindow:) description:@"List tabs in specific window"];
     [argonaut add:@"list links" target:app action:@selector(listTabsLinks:) description:@"List all tabs' link"];
     [argonaut add:@"list links -w <id>" target:app action:@selector(listTabsLinksInWindow:) description:@"List tabs' link in specific window"];
+    [argonaut add:@"list tablinks" target:app action:@selector(listTabsWithLink:) description:@"List tabs' with the link"];
 
 
     [argonaut add:@"info" target:app action:@selector(printActiveTabInfo:) description:@"Print info for active tab"];


### PR DESCRIPTION
Thanks for the maintenance of chrome-cli. 
Now, there are two types of acquisition of tabs and links respectively, but I had a personal request to acquire tabs and links at once while using chrome-cli. I personally implemented it and used it, but there was the same opinion in the issue, so I submitted a PR.